### PR TITLE
refactor: rename "params" to "batch"

### DIFF
--- a/src/SablierV2ProxyTarget.sol
+++ b/src/SablierV2ProxyTarget.sol
@@ -42,9 +42,9 @@ contract SablierV2ProxyTarget is ISablierV2ProxyTarget {
     //////////////////////////////////////////////////////////////////////////*/
 
     /// @inheritdoc ISablierV2ProxyTarget
-    function batchCancelMultiple(Batch.CancelMultiple[] calldata params, IERC20[] calldata assets) external {
+    function batchCancelMultiple(Batch.CancelMultiple[] calldata batch, IERC20[] calldata assets) external {
         // Check that the batch size is not zero.
-        uint256 batchSize = params.length;
+        uint256 batchSize = batch.length;
         if (batchSize == 0) {
             revert Errors.SablierV2ProxyTarget_BatchSizeZero();
         }
@@ -54,7 +54,7 @@ contract SablierV2ProxyTarget is ISablierV2ProxyTarget {
 
         for (uint256 i = 0; i < batchSize;) {
             // Cancel the streams.
-            params[i].lockup.cancelMultiple(params[i].streamIds);
+            batch[i].lockup.cancelMultiple(batch[i].streamIds);
 
             // Increment the for loop iterator.
             unchecked {
@@ -117,7 +117,7 @@ contract SablierV2ProxyTarget is ISablierV2ProxyTarget {
     function batchCreateWithDurations(
         ISablierV2LockupLinear linear,
         IERC20 asset,
-        Batch.CreateWithDurations[] calldata params,
+        Batch.CreateWithDurations[] calldata batch,
         Permit2Params calldata permit2Params
     )
         external
@@ -125,7 +125,7 @@ contract SablierV2ProxyTarget is ISablierV2ProxyTarget {
         returns (uint256[] memory streamIds)
     {
         // Check that the batch size is not zero.
-        uint256 batchSize = params.length;
+        uint256 batchSize = batch.length;
         if (batchSize == 0) {
             revert Errors.SablierV2ProxyTarget_BatchSizeZero();
         }
@@ -136,7 +136,7 @@ contract SablierV2ProxyTarget is ISablierV2ProxyTarget {
         uint128 transferAmount;
         for (i = 0; i < batchSize;) {
             unchecked {
-                transferAmount += params[i].totalAmount;
+                transferAmount += batch[i].totalAmount;
                 i += 1;
             }
         }
@@ -151,12 +151,12 @@ contract SablierV2ProxyTarget is ISablierV2ProxyTarget {
             streamIds[i] = linear.createWithDurations(
                 LockupLinear.CreateWithDurations({
                     asset: asset,
-                    broker: params[i].broker,
-                    cancelable: params[i].cancelable,
-                    durations: params[i].durations,
-                    recipient: params[i].recipient,
-                    sender: params[i].sender,
-                    totalAmount: params[i].totalAmount
+                    broker: batch[i].broker,
+                    cancelable: batch[i].cancelable,
+                    durations: batch[i].durations,
+                    recipient: batch[i].recipient,
+                    sender: batch[i].sender,
+                    totalAmount: batch[i].totalAmount
                 })
             );
 
@@ -171,7 +171,7 @@ contract SablierV2ProxyTarget is ISablierV2ProxyTarget {
     function batchCreateWithRange(
         ISablierV2LockupLinear linear,
         IERC20 asset,
-        Batch.CreateWithRange[] calldata params,
+        Batch.CreateWithRange[] calldata batch,
         Permit2Params calldata permit2Params
     )
         external
@@ -179,7 +179,7 @@ contract SablierV2ProxyTarget is ISablierV2ProxyTarget {
         returns (uint256[] memory streamIds)
     {
         // Check that the batch is not empty.
-        uint256 batchSize = params.length;
+        uint256 batchSize = batch.length;
         if (batchSize == 0) {
             revert Errors.SablierV2ProxyTarget_BatchSizeZero();
         }
@@ -190,7 +190,7 @@ contract SablierV2ProxyTarget is ISablierV2ProxyTarget {
         uint128 transferAmount;
         for (i = 0; i < batchSize;) {
             unchecked {
-                transferAmount += params[i].totalAmount;
+                transferAmount += batch[i].totalAmount;
                 i += 1;
             }
         }
@@ -205,12 +205,12 @@ contract SablierV2ProxyTarget is ISablierV2ProxyTarget {
             streamIds[i] = linear.createWithRange(
                 LockupLinear.CreateWithRange({
                     asset: asset,
-                    broker: params[i].broker,
-                    cancelable: params[i].cancelable,
-                    range: params[i].range,
-                    recipient: params[i].recipient,
-                    sender: params[i].sender,
-                    totalAmount: params[i].totalAmount
+                    broker: batch[i].broker,
+                    cancelable: batch[i].cancelable,
+                    range: batch[i].range,
+                    recipient: batch[i].recipient,
+                    sender: batch[i].sender,
+                    totalAmount: batch[i].totalAmount
                 })
             );
 
@@ -335,7 +335,7 @@ contract SablierV2ProxyTarget is ISablierV2ProxyTarget {
     function batchCreateWithDeltas(
         ISablierV2LockupDynamic dynamic,
         IERC20 asset,
-        Batch.CreateWithDeltas[] calldata params,
+        Batch.CreateWithDeltas[] calldata batch,
         Permit2Params calldata permit2Params
     )
         external
@@ -343,7 +343,7 @@ contract SablierV2ProxyTarget is ISablierV2ProxyTarget {
         returns (uint256[] memory streamIds)
     {
         // Check that the batch size is not zero.
-        uint256 batchSize = params.length;
+        uint256 batchSize = batch.length;
         if (batchSize == 0) {
             revert Errors.SablierV2ProxyTarget_BatchSizeZero();
         }
@@ -354,7 +354,7 @@ contract SablierV2ProxyTarget is ISablierV2ProxyTarget {
         uint128 transferAmount;
         for (i = 0; i < batchSize;) {
             unchecked {
-                transferAmount += params[i].totalAmount;
+                transferAmount += batch[i].totalAmount;
                 i += 1;
             }
         }
@@ -369,12 +369,12 @@ contract SablierV2ProxyTarget is ISablierV2ProxyTarget {
             streamIds[i] = dynamic.createWithDeltas(
                 LockupDynamic.CreateWithDeltas({
                     asset: asset,
-                    broker: params[i].broker,
-                    cancelable: params[i].cancelable,
-                    recipient: params[i].recipient,
-                    segments: params[i].segments,
-                    sender: params[i].sender,
-                    totalAmount: params[i].totalAmount
+                    broker: batch[i].broker,
+                    cancelable: batch[i].cancelable,
+                    recipient: batch[i].recipient,
+                    segments: batch[i].segments,
+                    sender: batch[i].sender,
+                    totalAmount: batch[i].totalAmount
                 })
             );
 
@@ -389,7 +389,7 @@ contract SablierV2ProxyTarget is ISablierV2ProxyTarget {
     function batchCreateWithMilestones(
         ISablierV2LockupDynamic dynamic,
         IERC20 asset,
-        Batch.CreateWithMilestones[] calldata params,
+        Batch.CreateWithMilestones[] calldata batch,
         Permit2Params calldata permit2Params
     )
         external
@@ -397,7 +397,7 @@ contract SablierV2ProxyTarget is ISablierV2ProxyTarget {
         returns (uint256[] memory streamIds)
     {
         // Check that the batch size is not zero.
-        uint256 batchSize = params.length;
+        uint256 batchSize = batch.length;
         if (batchSize == 0) {
             revert Errors.SablierV2ProxyTarget_BatchSizeZero();
         }
@@ -408,7 +408,7 @@ contract SablierV2ProxyTarget is ISablierV2ProxyTarget {
         uint128 transferAmount;
         for (i = 0; i < batchSize;) {
             unchecked {
-                transferAmount += params[i].totalAmount;
+                transferAmount += batch[i].totalAmount;
                 i += 1;
             }
         }
@@ -423,13 +423,13 @@ contract SablierV2ProxyTarget is ISablierV2ProxyTarget {
             streamIds[i] = dynamic.createWithMilestones(
                 LockupDynamic.CreateWithMilestones({
                     asset: asset,
-                    broker: params[i].broker,
-                    cancelable: params[i].cancelable,
-                    recipient: params[i].recipient,
-                    segments: params[i].segments,
-                    sender: params[i].sender,
-                    startTime: params[i].startTime,
-                    totalAmount: params[i].totalAmount
+                    broker: batch[i].broker,
+                    cancelable: batch[i].cancelable,
+                    recipient: batch[i].recipient,
+                    segments: batch[i].segments,
+                    sender: batch[i].sender,
+                    startTime: batch[i].startTime,
+                    totalAmount: batch[i].totalAmount
                 })
             );
 

--- a/src/interfaces/ISablierV2ProxyTarget.sol
+++ b/src/interfaces/ISablierV2ProxyTarget.sol
@@ -22,12 +22,12 @@ interface ISablierV2ProxyTarget {
     /// @dev Notes:
     /// - At least one set of streams must be canceled.
     /// - All refunded assets are forwarded to the proxy owner.
-    /// - It is assumed that `assets` includes all the assets associated with `params.streamIds`. If any asset
+    /// - It is assumed that `assets` includes all assets associated with the stream ids in `batch`. If any asset
     /// is missing, the refunded amount will be left in the proxy.
     ///
-    /// @param params Struct encapsulating the lockup contract's address and the stream ids to cancel.
+    /// @param batch Struct encapsulating the lockup contract's address and the stream ids to cancel.
     /// @param assets The contract addresses of the ERC-20 assets used for streaming.
-    function batchCancelMultiple(Batch.CancelMultiple[] calldata params, IERC20[] calldata assets) external;
+    function batchCancelMultiple(Batch.CancelMultiple[] calldata batch, IERC20[] calldata assets) external;
 
     /// @notice Mirror for {ISablierV2Lockup.cancel}.
     function cancel(ISablierV2Lockup lockup, uint256 streamId) external;
@@ -36,8 +36,8 @@ interface ISablierV2ProxyTarget {
     ///
     /// @dev Notes:
     /// - All refunded assets are forwarded to the proxy owner.
-    /// - It is assumed that `assets` includes all the assets associated with `params.streamIds`. If any asset
-    /// is missing, the refunded amount will be left in the proxy.
+    /// - It is assumed that `assets` includes all assets associated with `streamIds`. If any asset is missing, the
+    /// refunded amount will be left in the proxy.
     ///
     /// @param lockup The address of the lockup streaming contract.
     /// @param assets The contract addresses of the ERC-20 assets used for streaming.
@@ -65,13 +65,13 @@ interface ISablierV2ProxyTarget {
     ///
     /// @param linear The address of the {SablierV2LockupLinear} contract.
     /// @param asset The contract address of the ERC-20 asset used for streaming.
-    /// @param params Struct encapsulating a subset of the parameters of {SablierV2LockupLinear.createWithDurations}.
+    /// @param batch Struct encapsulating a subset of the parameters of {SablierV2LockupLinear.createWithDurations}.
     /// @param permit2Params Struct encapsulating the user parameters needed for Permit2.
     /// @return streamIds The ids of the newly created streams.
     function batchCreateWithDurations(
         ISablierV2LockupLinear linear,
         IERC20 asset,
-        Batch.CreateWithDurations[] calldata params,
+        Batch.CreateWithDurations[] calldata batch,
         Permit2Params calldata permit2Params
     )
         external
@@ -85,13 +85,13 @@ interface ISablierV2ProxyTarget {
     ///
     /// @param linear The address of the {SablierV2LockupLinear} contract.
     /// @param asset The contract address of the ERC-20 asset used for streaming.
-    /// @param params Struct encapsulating a subset of the parameters of {SablierV2LockupLinear.createWithRange}.
+    /// @param batch Struct encapsulating a subset of the parameters of {SablierV2LockupLinear.createWithRange}.
     /// @param permit2Params Struct encapsulating the user parameters needed for Permit2.
     /// @return streamIds The ids of the newly created streams.
     function batchCreateWithRange(
         ISablierV2LockupLinear linear,
         IERC20 asset,
-        Batch.CreateWithRange[] calldata params,
+        Batch.CreateWithRange[] calldata batch,
         Permit2Params calldata permit2Params
     )
         external
@@ -205,13 +205,13 @@ interface ISablierV2ProxyTarget {
     ///
     /// @param dynamic The address of the {SablierV2LockupDynamic} contract.
     /// @param asset The contract address of the ERC-20 asset used for streaming.
-    /// @param params Struct encapsulating a subset of the parameters of {SablierV2LockupDynamic.createWithDeltas}.
+    /// @param batch Struct encapsulating a subset of the parameters of {SablierV2LockupDynamic.createWithDeltas}.
     /// @param permit2Params Struct encapsulating the user parameters needed for Permit2.
     /// @return streamIds The ids of the newly created streams.
     function batchCreateWithDeltas(
         ISablierV2LockupDynamic dynamic,
         IERC20 asset,
-        Batch.CreateWithDeltas[] calldata params,
+        Batch.CreateWithDeltas[] calldata batch,
         Permit2Params calldata permit2Params
     )
         external
@@ -245,6 +245,7 @@ interface ISablierV2ProxyTarget {
     ///
     /// @param lockup The address of the lockup streaming contract where the stream to cancel is.
     /// @param dynamic The address of the {SablierV2LockupDynamic} contract to use for creating the new stream.
+    /// @param params Struct encapsulating a subset of the parameters of {SablierV2LockupDynamic.createWithDeltas}.
     /// @param permit2Params Struct encapsulating the user parameters needed for Permit2.
     /// @return newStreamId The id of the newly created stream.
     function cancelAndCreateWithDeltas(
@@ -265,13 +266,14 @@ interface ISablierV2ProxyTarget {
     ///
     /// @param lockup The address of the lockup streaming contract where the stream to cancel is.
     /// @param dynamic The address of the {SablierV2LockupDynamic} contract to use for creating the new stream.
+    /// @param batch Struct encapsulating a subset of the parameters of {SablierV2LockupDynamic.createWithMilestones}.
     /// @param permit2Params Struct encapsulating the user parameters needed for Permit2.
     /// @return newStreamId The id of the newly created stream.
     function cancelAndCreateWithMilestones(
         ISablierV2Lockup lockup,
         ISablierV2LockupDynamic dynamic,
         uint256 streamId,
-        LockupDynamic.CreateWithMilestones calldata params,
+        LockupDynamic.CreateWithMilestones calldata batch,
         Permit2Params calldata permit2Params
     )
         external

--- a/test/helpers/Defaults.t.sol
+++ b/test/helpers/Defaults.t.sol
@@ -239,11 +239,11 @@ library Defaults {
     )
         internal
         pure
-        returns (Batch.CreateWithDeltas[] memory params)
+        returns (Batch.CreateWithDeltas[] memory batch)
     {
-        params = new Batch.CreateWithDeltas[](BATCH_SIZE);
+        batch = new Batch.CreateWithDeltas[](BATCH_SIZE);
         for (uint256 i = 0; i < BATCH_SIZE; ++i) {
-            params[i] = Batch.CreateWithDeltas({
+            batch[i] = Batch.CreateWithDeltas({
                 broker: Broker({ account: users.broker.addr, fee: BROKER_FEE }),
                 cancelable: true,
                 recipient: users.recipient.addr,
@@ -261,11 +261,11 @@ library Defaults {
     )
         internal
         pure
-        returns (Batch.CreateWithDurations[] memory params)
+        returns (Batch.CreateWithDurations[] memory batch)
     {
-        params = new Batch.CreateWithDurations[](BATCH_SIZE);
+        batch = new Batch.CreateWithDurations[](BATCH_SIZE);
         for (uint256 i = 0; i < BATCH_SIZE; ++i) {
-            params[i] = Batch.CreateWithDurations({
+            batch[i] = Batch.CreateWithDurations({
                 broker: Broker({ account: users.broker.addr, fee: BROKER_FEE }),
                 cancelable: true,
                 durations: durations(),
@@ -283,11 +283,11 @@ library Defaults {
     )
         internal
         pure
-        returns (Batch.CreateWithMilestones[] memory params)
+        returns (Batch.CreateWithMilestones[] memory batch)
     {
-        params = new Batch.CreateWithMilestones[](BATCH_SIZE);
+        batch = new Batch.CreateWithMilestones[](BATCH_SIZE);
         for (uint256 i = 0; i < BATCH_SIZE; ++i) {
-            params[i] = Batch.CreateWithMilestones({
+            batch[i] = Batch.CreateWithMilestones({
                 broker: Broker({ account: users.broker.addr, fee: BROKER_FEE }),
                 cancelable: true,
                 recipient: users.recipient.addr,
@@ -306,11 +306,11 @@ library Defaults {
     )
         internal
         pure
-        returns (Batch.CreateWithRange[] memory params)
+        returns (Batch.CreateWithRange[] memory batch)
     {
-        params = new Batch.CreateWithRange[](BATCH_SIZE);
+        batch = new Batch.CreateWithRange[](BATCH_SIZE);
         for (uint256 i = 0; i < BATCH_SIZE; ++i) {
-            params[i] = Batch.CreateWithRange({
+            batch[i] = Batch.CreateWithRange({
                 broker: Broker({ account: users.broker.addr, fee: BROKER_FEE }),
                 cancelable: true,
                 range: linearRange(),

--- a/test/unit/batch-cancel-multiple/batchCancelMultiple.t.sol
+++ b/test/unit/batch-cancel-multiple/batchCancelMultiple.t.sol
@@ -11,9 +11,9 @@ import { Defaults } from "../../helpers/Defaults.t.sol";
 
 contract BatchCancelMultiple_Unit_Test is Base_Test {
     function test_RevertWhen_BatchSizeZero() external {
-        Batch.CancelMultiple[] memory params = new Batch.CancelMultiple[](0);
+        Batch.CancelMultiple[] memory batch = new Batch.CancelMultiple[](0);
         vm.expectRevert(Errors.SablierV2ProxyTarget_BatchSizeZero.selector);
-        bytes memory data = abi.encodeCall(target.batchCancelMultiple, (params, Defaults.assets(dai)));
+        bytes memory data = abi.encodeCall(target.batchCancelMultiple, (batch, Defaults.assets(dai)));
         proxy.execute(address(target), data);
     }
 
@@ -40,10 +40,10 @@ contract BatchCancelMultiple_Unit_Test is Base_Test {
         expectCallToTransfer({ to: users.sender.addr, amount: 2 * Defaults.BATCH_SIZE * Defaults.REFUND_AMOUNT });
 
         // ABI encode the parameters and call the function via the proxy.
-        Batch.CancelMultiple[] memory params = new Batch.CancelMultiple[](2);
-        params[0] = Batch.CancelMultiple(dynamic, dynamicStreamIds);
-        params[1] = Batch.CancelMultiple(linear, linearStreamIds);
-        bytes memory data = abi.encodeCall(target.batchCancelMultiple, (params, Defaults.assets(dai)));
+        Batch.CancelMultiple[] memory batch = new Batch.CancelMultiple[](2);
+        batch[0] = Batch.CancelMultiple(dynamic, dynamicStreamIds);
+        batch[1] = Batch.CancelMultiple(linear, linearStreamIds);
+        bytes memory data = abi.encodeCall(target.batchCancelMultiple, (batch, Defaults.assets(dai)));
         proxy.execute(address(target), data);
 
         // Assert that all streams have been marked as canceled.

--- a/test/unit/batch-create-with-deltas/batchCreateWithDeltas.t.sol
+++ b/test/unit/batch-create-with-deltas/batchCreateWithDeltas.t.sol
@@ -9,11 +9,10 @@ import { Defaults } from "../../helpers/Defaults.t.sol";
 
 contract BatchCreateWithDeltas_Unit_Test is Base_Test {
     function test_RevertWhen_BatchSizeZero() external {
-        Batch.CreateWithDeltas[] memory params = new Batch.CreateWithDeltas[](0);
+        Batch.CreateWithDeltas[] memory batch = new Batch.CreateWithDeltas[](0);
         vm.expectRevert(Errors.SablierV2ProxyTarget_BatchSizeZero.selector);
-        bytes memory data = abi.encodeCall(
-            target.batchCreateWithDeltas, (dynamic, dai, params, permit2Params(Defaults.TRANSFER_AMOUNT))
-        );
+        bytes memory data =
+            abi.encodeCall(target.batchCreateWithDeltas, (dynamic, dai, batch, permit2Params(Defaults.TRANSFER_AMOUNT)));
         proxy.execute(address(target), data);
     }
 

--- a/test/unit/batch-create-with-durations/batchCreateWithDurations.t.sol
+++ b/test/unit/batch-create-with-durations/batchCreateWithDurations.t.sol
@@ -9,10 +9,10 @@ import { Defaults } from "../../helpers/Defaults.t.sol";
 
 contract BatchCreateWithDurations_Unit_Test is Base_Test {
     function test_RevertWhen_BatchSizeZero() external {
-        Batch.CreateWithDurations[] memory params = new Batch.CreateWithDurations[](0);
+        Batch.CreateWithDurations[] memory batch = new Batch.CreateWithDurations[](0);
         vm.expectRevert(Errors.SablierV2ProxyTarget_BatchSizeZero.selector);
         bytes memory data = abi.encodeCall(
-            target.batchCreateWithDurations, (linear, dai, params, permit2Params(Defaults.TRANSFER_AMOUNT))
+            target.batchCreateWithDurations, (linear, dai, batch, permit2Params(Defaults.TRANSFER_AMOUNT))
         );
         proxy.execute(address(target), data);
     }

--- a/test/unit/batch-create-with-milestones/batchCreateWithMilestones.t.sol
+++ b/test/unit/batch-create-with-milestones/batchCreateWithMilestones.t.sol
@@ -9,10 +9,10 @@ import { Defaults } from "../../helpers/Defaults.t.sol";
 
 contract BatchCreateWithMilestones_Unit_Test is Base_Test {
     function test_RevertWhen_BatchSizeZero() external {
-        Batch.CreateWithMilestones[] memory params = new Batch.CreateWithMilestones[](0);
+        Batch.CreateWithMilestones[] memory batch = new Batch.CreateWithMilestones[](0);
         vm.expectRevert(Errors.SablierV2ProxyTarget_BatchSizeZero.selector);
         bytes memory data = abi.encodeCall(
-            target.batchCreateWithMilestones, (dynamic, dai, params, permit2Params(Defaults.TRANSFER_AMOUNT))
+            target.batchCreateWithMilestones, (dynamic, dai, batch, permit2Params(Defaults.TRANSFER_AMOUNT))
         );
         proxy.execute(address(target), data);
     }

--- a/test/unit/batch-create-with-range/batchCreateWithRange.t.sol
+++ b/test/unit/batch-create-with-range/batchCreateWithRange.t.sol
@@ -9,10 +9,10 @@ import { Defaults } from "../../helpers/Defaults.t.sol";
 
 contract BatchCreateWithRange_Unit_Test is Base_Test {
     function test_RevertWhen_BatchSizeZero() external {
-        Batch.CreateWithRange[] memory params = new Batch.CreateWithRange[](0);
+        Batch.CreateWithRange[] memory batch = new Batch.CreateWithRange[](0);
         vm.expectRevert(Errors.SablierV2ProxyTarget_BatchSizeZero.selector);
         bytes memory data =
-            abi.encodeCall(target.batchCreateWithRange, (linear, dai, params, permit2Params(Defaults.TRANSFER_AMOUNT)));
+            abi.encodeCall(target.batchCreateWithRange, (linear, dai, batch, permit2Params(Defaults.TRANSFER_AMOUNT)));
         proxy.execute(address(target), data);
     }
 


### PR DESCRIPTION
The current name for the "params" parameter of the batch functions is confusing. The term "params" is reserved for the struct-encoded function parameters in Sablier V2 Core. By re-using it in the batch functions, we have inadvertently given it a double meaning, i.e. "params" also means an array of "params".

To clear up the confusion, this commit renames the "params" parameter to "batch" in all batch functions. Basically, a "batch" means an array of params now.