### PR TITLE
refactor: rename "UnlistedCaller" to "UnknownCaller"

### DIFF
--- a/src/SablierV2ProxyPlugin.sol
+++ b/src/SablierV2ProxyPlugin.sol
@@ -74,7 +74,7 @@ contract SablierV2ProxyPlugin is
     /// proxy contract.
     /// @dev Requirements:
     /// - Must be delegate called.
-    /// - The caller must be Sablier.
+    /// - The caller must be an address listed in the archive.
     function onStreamCanceled(
         uint256 streamId,
         address, /* recipient */
@@ -86,7 +86,7 @@ contract SablierV2ProxyPlugin is
     {
         // Checks: the caller is an address listed in the archive.
         if (!archive.isListed(msg.sender)) {
-            revert Errors.SablierV2ProxyPlugin_CallerUnlisted(msg.sender);
+            revert Errors.SablierV2ProxyPlugin_UnknownCaller(msg.sender);
         }
 
         // This invariant should always hold but it's better to be safe than sorry.

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -15,8 +15,8 @@ library Errors {
                               SABLIER-V2-PROXY-PLUGIN
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @notice Thrown when the caller is not a contract listed in the archive.
-    error SablierV2ProxyPlugin_CallerUnlisted(address caller);
+    /// @notice Thrown when the caller is an unknown address, which is not listed in the archive.
+    error SablierV2ProxyPlugin_UnknownCaller(address caller);
 
     /*//////////////////////////////////////////////////////////////////////////
                               SABLIER-V2-PROXY-TARGET

--- a/test/integration/plugin/on-stream-canceled/onStreamCanceled.t.sol
+++ b/test/integration/plugin/on-stream-canceled/onStreamCanceled.t.sol
@@ -38,7 +38,7 @@ contract OnStreamCanceled_Integration_Test is Integration_Test {
 
     function test_RevertWhen_CallerNotListed() external whenDelegateCalled {
         changePrank({ msgSender: users.eve.addr });
-        vm.expectRevert(abi.encodeWithSelector(Errors.SablierV2ProxyPlugin_CallerUnlisted.selector, users.eve.addr));
+        vm.expectRevert(abi.encodeWithSelector(Errors.SablierV2ProxyPlugin_UnknownCaller.selector, users.eve.addr));
         ISablierV2ProxyPlugin(address(proxy)).onStreamCanceled({
             streamId: streamId,
             recipient: users.recipient.addr,


### PR DESCRIPTION
"Unlisted" can be misinterpreted as meaning "address was listed before but has since been unlisted".

"Unknown" is much more suggestive.