### PR TITLE
build: increase optimizer runs

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -12,7 +12,7 @@
   ]
   libs = ["lib"]
   optimizer = true
-  optimizer_runs = 5_000
+  optimizer_runs = 10_000
   out = "out"
   script = "script"
   solc = "0.8.19"


### PR DESCRIPTION
This PR increases the `optimizer_runs` to 10k - the contracts are well below the EIP-170 limit of ~24kB.

Side note: we should implement a script similar to Seaport's [`find_optimizer_runs.sh`](https://github.com/ProjectOpenSea/seaport/blob/5723c767e1c7750d0ef94e1d1173ca6643bb0c60/scripts/find_optimizer_runs.sh).