### PR TITLE
build: add "prepack" Node.js script

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "gas:snapshot:optimized": "pnpm build:optimized && FOUNDRY_PROFILE=test-optimized forge snapshot --no-match-test \"test(Fork)?(Fuzz)?_RevertWhen_\\w{1,}?\"",
     "lint": "pnpm lint:sol && pnpm prettier:check",
     "lint:sol": "forge fmt --check && pnpm solhint \"{script,src,test}/**/*.sol\"",
+    "prepack": "bash ./shell/prepare-artifacts.sh",
     "prettier:check": "prettier --check \"**/*.{json,md,yml}\"",
     "prettier:write": "prettier --write \"**/*.{json,md,yml}\"",
     "test": "forge test",


### PR DESCRIPTION
Defines the Node.js lifecycle script `prepack`, which runs before `npm pubish` and `npm pack`:

https://docs.npmjs.com/cli/v9/using-npm/scripts/#life-cycle-scripts