### PR TITLE
refactor: stringify create2 salts

### DIFF
--- a/script/DeployDeterministicArchive.s.sol
+++ b/script/DeployDeterministicArchive.s.sol
@@ -11,7 +11,7 @@ contract DeployDeterministicArchive is BaseScript {
     /// @dev The presence of the salt instructs Forge to deploy contracts via this deterministic CREATE2 factory:
     /// https://github.com/Arachnid/deterministic-deployment-proxy
     function run(
-        uint256 create2Salt,
+        string memory create2Salt,
         address initialAdmin
     )
         public
@@ -19,6 +19,6 @@ contract DeployDeterministicArchive is BaseScript {
         broadcaster
         returns (SablierV2Archive archive)
     {
-        archive = new SablierV2Archive{ salt: bytes32(create2Salt) }(initialAdmin);
+        archive = new SablierV2Archive{ salt: bytes32(abi.encodePacked(create2Salt)) }(initialAdmin);
     }
 }

--- a/script/DeployDeterministicPeriphery.s.sol
+++ b/script/DeployDeterministicPeriphery.s.sol
@@ -19,7 +19,7 @@ contract DeployDeterministicPeriphery is BaseScript {
     /// @dev The presence of the salt instructs Forge to deploy the contract via a deterministic CREATE2 factory.
     /// https://github.com/Arachnid/deterministic-deployment-proxy
     function run(
-        uint256 create2Salt,
+        string memory create2Salt,
         address initialAdmin,
         IAllowanceTransfer permit2
     )
@@ -28,8 +28,8 @@ contract DeployDeterministicPeriphery is BaseScript {
         broadcaster
         returns (SablierV2Archive archive, SablierV2ProxyPlugin plugin, SablierV2ProxyTarget target)
     {
-        archive = new SablierV2Archive{ salt: bytes32(create2Salt) }(initialAdmin);
-        plugin = new SablierV2ProxyPlugin{ salt: bytes32(create2Salt) }(archive);
-        target = new SablierV2ProxyTarget{ salt: bytes32(create2Salt) }(permit2);
+        archive = new SablierV2Archive{ salt: bytes32(abi.encodePacked(create2Salt)) }(initialAdmin);
+        plugin = new SablierV2ProxyPlugin{ salt: bytes32(abi.encodePacked(create2Salt)) }(archive);
+        target = new SablierV2ProxyTarget{ salt: bytes32(abi.encodePacked(create2Salt)) }(permit2);
     }
 }

--- a/script/DeployDeterministicProxyPlugin.s.sol
+++ b/script/DeployDeterministicProxyPlugin.s.sol
@@ -12,7 +12,7 @@ contract DeployDeterministicProxyPlugin is BaseScript {
     /// @dev The presence of the salt instructs Forge to deploy contracts via this deterministic CREATE2 factory:
     /// https://github.com/Arachnid/deterministic-deployment-proxy
     function run(
-        uint256 create2Salt,
+        string memory create2Salt,
         ISablierV2Archive archive
     )
         public
@@ -20,6 +20,6 @@ contract DeployDeterministicProxyPlugin is BaseScript {
         broadcaster
         returns (SablierV2ProxyPlugin plugin)
     {
-        plugin = new SablierV2ProxyPlugin{ salt: bytes32(create2Salt) }(archive);
+        plugin = new SablierV2ProxyPlugin{ salt: bytes32(abi.encodePacked(create2Salt)) }(archive);
     }
 }

--- a/script/DeployDeterministicProxyTarget.s.sol
+++ b/script/DeployDeterministicProxyTarget.s.sol
@@ -12,7 +12,7 @@ contract DeployDeterministicProxyTarget is BaseScript {
     /// @dev The presence of the salt instructs Forge to deploy contracts via this deterministic CREATE2 factory:
     /// https://github.com/Arachnid/deterministic-deployment-proxy
     function run(
-        uint256 create2Salt,
+        string memory create2Salt,
         IAllowanceTransfer permit2
     )
         public
@@ -20,6 +20,6 @@ contract DeployDeterministicProxyTarget is BaseScript {
         broadcaster
         returns (SablierV2ProxyTarget target)
     {
-        target = new SablierV2ProxyTarget{ salt: bytes32(create2Salt) }(permit2);
+        target = new SablierV2ProxyTarget{ salt: bytes32(abi.encodePacked(create2Salt)) }(permit2);
     }
 }


### PR DESCRIPTION
Using strings for the `create2Salt` parameter allows us to use the version as a CREATE2 salt, e.g.

- `1.0.0-rc.0`
- `ProxyTarget v1.0.0-rc.0`
- `SablierV2ProxyTarget v1.0.0-rc.0`