### PR TITLE
use solhint-community

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "prettier": "^2.8.8",
-    "solhint": "^3.4.1"
+    "solhint-community": "^3.7.0-rc00"
   },
   "files": [
     "artifacts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true
@@ -22,9 +22,9 @@ devDependencies:
   prettier:
     specifier: ^2.8.8
     version: 2.8.8
-  solhint:
-    specifier: ^3.4.1
-    version: 3.4.1
+  solhint-community:
+    specifier: ^3.7.0-rc00
+    version: 3.7.0-rc00
 
 packages:
 
@@ -399,8 +399,8 @@ packages:
       is-fullwidth-code-point: 3.0.0
     dev: true
 
-  /solhint@3.4.1:
-    resolution: {integrity: sha512-pzZn2RlZhws1XwvLPVSsxfHrwsteFf5eySOhpAytzXwKQYbTCJV6z8EevYDiSVKMpWrvbKpEtJ055CuEmzp4Xg==}
+  /solhint-community@3.7.0-rc00:
+    resolution: {integrity: sha512-Csl2nyBoJ64f1cWev8U0Tw1gRB5v8FQP3UyWm5IjlFZfAMxCNxQ/Mh2yN3A1y5dt5oLlk1bbwlmKengoHwf9ag==}
     hasBin: true
     dependencies:
       '@solidity-parser/parser': 0.16.0

--- a/src/types/Permit2.sol
+++ b/src/types/Permit2.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// solhint-disable no-unused-import
 pragma solidity >=0.8.19;
 
 import { IAllowanceTransfer } from "@uniswap/permit2/interfaces/IAllowanceTransfer.sol";
-// solhint-disable-next-line no-unused-import
 import { IPermit2 } from "@uniswap/permit2/interfaces/IPermit2.sol"; // unused but re-exported for convenience
 
 /// @notice A struct encapsulating the parameters needed for Permit2.

--- a/src/types/Permit2.sol
+++ b/src/types/Permit2.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.8.19;
 
 import { IAllowanceTransfer } from "@uniswap/permit2/interfaces/IAllowanceTransfer.sol";
+// solhint-disable-next-line no-unused-import
 import { IPermit2 } from "@uniswap/permit2/interfaces/IPermit2.sol"; // unused but re-exported for convenience
 
 /// @notice A struct encapsulating the parameters needed for Permit2.

--- a/src/types/Proxy.sol
+++ b/src/types/Proxy.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// solhint-disable no-unused-import
 pragma solidity >=0.8.19;
 
 // Proxy.sol
 //
 // This file re-exports all PRBProxy interfaces used in V2 Periphery. It is provided for convenience so
 // that users don't have to install PRBProxy separately.
-// solhint-disable no-unused-import
 
 import { IPRBProxy } from "@prb/proxy/interfaces/IPRBProxy.sol";
 import { IPRBProxyPlugin } from "@prb/proxy/interfaces/IPRBProxyPlugin.sol";

--- a/src/types/Proxy.sol
+++ b/src/types/Proxy.sol
@@ -5,6 +5,7 @@ pragma solidity >=0.8.19;
 //
 // This file re-exports all PRBProxy interfaces used in V2 Periphery. It is provided for convenience so
 // that users don't have to install PRBProxy separately.
+// solhint-disable no-unused-import
 
 import { IPRBProxy } from "@prb/proxy/interfaces/IPRBProxy.sol";
 import { IPRBProxyPlugin } from "@prb/proxy/interfaces/IPRBProxyPlugin.sol";


### PR DESCRIPTION
This PR
- switches from solhint to solhint-community, to just released version 3.6.0,
which includes fixes for several false positives previously reported
- has no-unused-imports enabled by default since the config extends the
recommended ruleset
- explicitly enables named-parameters-function and fixes a few instances of
invocations with 4+ positional arguments
