### PR TITLE
chore: remove "cbor_metadata"

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -2,7 +2,6 @@
   auto_detect_solc = false
   block_timestamp = 1_682_899_200 # May 1, 2023 at 00:00 GMT
   bytecode_hash = "none"
-  cbor_metadata = false
   evm_version = "paris"
   fs_permissions = [{ access = "read", path = "out-optimized" }]
   gas_reports = [


### PR DESCRIPTION
The CBOR metadata can be enabled as it won't affect deterministic compilation across operating systems.

Ref https://twitter.com/msolomon44/status/1659301831489757187