### PR TITLE
Hash all parameters in the salt 

### DIFF
--- a/src/SablierV2MerkleStreamerFactory.sol
+++ b/src/SablierV2MerkleStreamerFactory.sol
@@ -56,7 +56,18 @@ contract SablierV2MerkleStreamerFactory is ISablierV2MerkleStreamerFactory {
         returns (ISablierV2MerkleStreamerLL merkleStreamerLL)
     {
         // Hash the parameters to generate a salt.
-        bytes32 salt = keccak256(abi.encodePacked(initialAdmin, lockupLinear, asset, merkleRoot, expiration));
+        bytes32 salt = keccak256(
+            abi.encodePacked(
+                initialAdmin,
+                lockupLinear,
+                asset,
+                merkleRoot,
+                expiration,
+                keccak256(abi.encode(streamDurations)),
+                cancelable,
+                transferable
+            )
+        );
 
         // Deploy the Merkle streamer with CREATE2.
         merkleStreamerLL = new SablierV2MerkleStreamerLL{salt: salt} (

--- a/src/SablierV2MerkleStreamerFactory.sol
+++ b/src/SablierV2MerkleStreamerFactory.sol
@@ -63,22 +63,15 @@ contract SablierV2MerkleStreamerFactory is ISablierV2MerkleStreamerFactory {
                 asset,
                 merkleRoot,
                 expiration,
-                keccak256(abi.encode(streamDurations)),
+                abi.encode(streamDurations),
                 cancelable,
                 transferable
             )
         );
 
         // Deploy the Merkle streamer with CREATE2.
-        merkleStreamerLL = new SablierV2MerkleStreamerLL{salt: salt} (
-            initialAdmin,
-            lockupLinear,
-            asset,
-            merkleRoot,
-            expiration,
-            streamDurations,
-            cancelable,
-            transferable
+        merkleStreamerLL = new SablierV2MerkleStreamerLL{ salt: salt }(
+            initialAdmin, lockupLinear, asset, merkleRoot, expiration, streamDurations, cancelable, transferable
         );
 
         // Effects: append the streamer in the admin's list.

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -328,7 +328,18 @@ abstract contract Base_Test is DeployOptimized, Events, Merkle, V2CoreAssertions
         internal
         returns (address)
     {
-        bytes32 salt = keccak256(abi.encodePacked(admin, lockupLinear, asset, merkleRoot, expiration));
+        bytes32 salt = keccak256(
+            abi.encodePacked(
+                admin,
+                lockupLinear,
+                asset,
+                merkleRoot,
+                expiration,
+                keccak256(abi.encode(defaults.durations())),
+                defaults.CANCELABLE(),
+                defaults.TRANSFERABLE()
+            )
+        );
         bytes32 creationBytecodeHash = keccak256(getMerkleStreamerLLBytecode(admin, merkleRoot, expiration));
         return computeCreate2Address({
             salt: salt,

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -335,7 +335,7 @@ abstract contract Base_Test is DeployOptimized, Events, Merkle, V2CoreAssertions
                 asset,
                 merkleRoot,
                 expiration,
-                keccak256(abi.encode(defaults.durations())),
+                abi.encode(defaults.durations()),
                 defaults.CANCELABLE(),
                 defaults.TRANSFERABLE()
             )


### PR DESCRIPTION
We are using CREATE2 to deploy the airstream campaigns and we are not hashing all the inputs. 

This is an issue because a bad actor could match all the parameters intended by an organization, but set `streamDurations = (0, 0)`, which will unlock all tokens instantly, turning the airstream into an airdrop.