### PR TITLE
Add protocol fee variable in `claim` and `clawback` functions

### DIFF
--- a/src/SablierV2MerkleStreamerLL.sol
+++ b/src/SablierV2MerkleStreamerLL.sol
@@ -6,7 +6,7 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { ISablierV2LockupLinear } from "@sablier/v2-core/src/interfaces/ISablierV2LockupLinear.sol";
 import { Broker, LockupLinear } from "@sablier/v2-core/src/types/DataTypes.sol";
-import { ud60x18 } from "@sablier/v2-core/src/types/Math.sol";
+import { ud } from "@sablier/v2-core/src/types/Math.sol";
 
 import { SablierV2MerkleStreamer } from "./abstracts/SablierV2MerkleStreamer.sol";
 import { ISablierV2MerkleStreamerLL } from "./interfaces/ISablierV2MerkleStreamerLL.sol";
@@ -50,7 +50,7 @@ contract SablierV2MerkleStreamerLL is
         bool cancelable,
         bool transferable
     )
-        SablierV2MerkleStreamer(initialAdmin, asset, merkleRoot, expiration, cancelable, transferable)
+        SablierV2MerkleStreamer(initialAdmin, asset, lockupLinear, merkleRoot, expiration, cancelable, transferable)
     {
         LOCKUP_LINEAR = lockupLinear;
         streamDurations = streamDurations_;
@@ -88,7 +88,7 @@ contract SablierV2MerkleStreamerLL is
         streamId = LOCKUP_LINEAR.createWithDurations(
             LockupLinear.CreateWithDurations({
                 asset: ASSET,
-                broker: Broker({ account: address(0), fee: ud60x18(0) }),
+                broker: Broker({ account: address(0), fee: ud(0) }),
                 cancelable: CANCELABLE,
                 durations: streamDurations,
                 recipient: recipient,

--- a/src/interfaces/ISablierV2MerkleStreamer.sol
+++ b/src/interfaces/ISablierV2MerkleStreamer.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.19;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IAdminable } from "@sablier/v2-core/src/interfaces/IAdminable.sol";
+import { ISablierV2Lockup } from "@sablier/v2-core/src/interfaces/ISablierV2Lockup.sol";
 
 /// @title ISablierV2MerkleStreamer
 /// @notice A contract that lets user claim Sablier streams using Merkle proofs. An interesting use case for
@@ -46,6 +47,9 @@ interface ISablierV2MerkleStreamer is IAdminable {
 
     /// @notice Returns a flag indicating whether the Merkle streamer has expired.
     function hasExpired() external view returns (bool);
+
+    /// @notice The address of the {SablierV2Lockup} contract.
+    function LOCKUP() external returns (ISablierV2Lockup);
 
     /// @notice The root of the Merkle tree used to validate the claims.
     /// @dev This is an immutable state variable.

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -21,17 +21,23 @@ library Errors {
                              SABLIER-V2-MERKLE-STREAMER
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @notice Thrown when trying to claim the same stream more than once.
-    error SablierV2MerkleStreamer_StreamClaimed(uint256 index);
-
     /// @notice Thrown when trying to claim after the campaign has expired.
     error SablierV2MerkleStreamer_CampaignExpired(uint256 currentTime, uint40 expiration);
 
-    /// @notice Thrown when trying to claim when Merkle streamer has not expired.
+    /// @notice Thrown when trying to clawback when the campaign has not expired.
     error SablierV2MerkleStreamer_CampaignNotExpired(uint256 currentTime, uint40 expiration);
 
     /// @notice Thrown when trying to claim with an invalid Merkle proof.
     error SablierV2MerkleStreamer_InvalidProof();
+
+    /// @notice Thrown when trying to clawback when the protocol fee is zero.
+    error SablierV2MerkleStreamer_ProtocolFeeZero();
+
+    /// @notice Thrown when trying to claim when the protocol fee is not zero.
+    error SablierV2MerkleStreamer_ProtocolFeeNotZero();
+
+    /// @notice Thrown when trying to claim the same stream more than once.
+    error SablierV2MerkleStreamer_StreamClaimed(uint256 index);
 
     /*//////////////////////////////////////////////////////////////////////////
                               SABLIER-V2-PROXY-TARGET

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -7,6 +7,7 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import { IPRBProxy } from "@prb/proxy/src/interfaces/IPRBProxy.sol";
 import { IPRBProxyRegistry } from "@prb/proxy/src/interfaces/IPRBProxyRegistry.sol";
+import { ISablierV2Comptroller } from "@sablier/v2-core/src/interfaces/ISablierV2Comptroller.sol";
 import { ISablierV2Lockup } from "@sablier/v2-core/src/interfaces/ISablierV2Lockup.sol";
 import { ISablierV2LockupDynamic } from "@sablier/v2-core/src/interfaces/ISablierV2LockupDynamic.sol";
 import { ISablierV2LockupLinear } from "@sablier/v2-core/src/interfaces/ISablierV2LockupLinear.sol";
@@ -50,6 +51,7 @@ abstract contract Base_Test is DeployOptimized, Events, Merkle, V2CoreAssertions
     IPRBProxy internal aliceProxy;
     IERC20 internal asset;
     ISablierV2Batch internal batch;
+    ISablierV2Comptroller internal comptroller;
     Defaults internal defaults;
     ISablierV2LockupDynamic internal lockupDynamic;
     ISablierV2LockupLinear internal lockupLinear;
@@ -130,6 +132,7 @@ abstract contract Base_Test is DeployOptimized, Events, Merkle, V2CoreAssertions
         vm.label({ account: address(merkleStreamerFactory), newLabel: "MerkleStreamerFactory" });
         vm.label({ account: address(merkleStreamerLL), newLabel: "MerkleStreamerLL" });
         vm.label({ account: address(defaults), newLabel: "Defaults" });
+        vm.label({ account: address(comptroller), newLabel: "Comptroller" });
         vm.label({ account: address(lockupDynamic), newLabel: "LockupDynamic" });
         vm.label({ account: address(lockupLinear), newLabel: "LockupLinear" });
         vm.label({ account: address(permit2), newLabel: "Permit2" });

--- a/test/integration/Integration.t.sol
+++ b/test/integration/Integration.t.sol
@@ -48,6 +48,6 @@ abstract contract Integration_Test is Base_Test {
         proxyRegistry = new PRBProxyPrecompiles().deployRegistry();
         aliceProxy = proxyRegistry.deployFor(users.alice.addr);
         permit2 = IAllowanceTransfer(new DeployPermit2().run());
-        (, lockupDynamic, lockupLinear,) = new V2CorePrecompiles().deployCore(users.admin.addr);
+        (comptroller, lockupDynamic, lockupLinear,) = new V2CorePrecompiles().deployCore(users.admin.addr);
     }
 }

--- a/test/integration/merkle-streamer/ll/claim/claim.tree
+++ b/test/integration/merkle-streamer/ll/claim/claim.tree
@@ -1,20 +1,23 @@
 claim.t.sol
-├── given the campaign has expired
+├── given the protocol fee is greater than zero
 │  └── it should revert
-└── given the campaign has not expired
-   ├── given the recipient has claimed
+└── given the protocol fee is not greater than zero
+   ├── given the campaign has expired
    │  └── it should revert
-   └── given the recipient has not claimed
-      ├── given the claim is not included in the Merkle tree
-      │  ├── when the index is not valid
-      │  │  └── it should revert
-      │  ├── when the recipient address is not valid
-      │  │  └── it should revert
-      │  ├── when the amount is not valid
-      │  │  └── it should revert
-      │  └── when the Merkle proof is not valid
-      │     └── it should revert
-      └── given the claim is included in the Merkle tree
-         ├── it should mark the index as claimed
-         ├── it should create a LockupLinear stream
-         └── it should emit a {Claim} event
+   └── given the campaign has not expired
+      ├── given the recipient has claimed
+      │  └── it should revert
+      └── given the recipient has not claimed
+         ├── given the claim is not included in the Merkle tree
+         │  ├── when the index is not valid
+         │  │  └── it should revert
+         │  ├── when the recipient address is not valid
+         │  │  └── it should revert
+         │  ├── when the amount is not valid
+         │  │  └── it should revert
+         │  └── when the Merkle proof is not valid
+         │     └── it should revert
+         └── given the claim is included in the Merkle tree
+            ├── it should mark the index as claimed
+            ├── it should create a LockupLinear stream
+            └── it should emit a {Claim} event

--- a/test/integration/merkle-streamer/ll/clawback/clawback.tree
+++ b/test/integration/merkle-streamer/ll/clawback/clawback.tree
@@ -2,8 +2,16 @@ clawback.t.sol
 ├── when the caller is not the admin
 │  └── it should revert
 └── when the caller is the admin
-   ├── given the campaign has not expired
-   │  └── it should revert
-   └── given the campaign has expired
-      ├── it should perform the ERC-20 transfer
-      └── it should emit a {Clawback} event
+   ├── given the protocol fee is not greater than zero
+   │  ├── given the campaign has not expired
+   │  │  └── it should revert
+   │  └── given the campaign has expired
+   │     ├── it should perform the ERC-20 transfer
+   │     └── it should emit a {Clawback} event
+   └── given the protocol fee is greater than zero
+         ├── given the campaign has not expired
+         │  ├── it should perform the ERC-20 transfer
+         │  └── it should emit a {Clawback} event
+         └── given the campaign has expired
+            ├── it should perform the ERC-20 transfer
+            └── it should emit a {Clawback} event


### PR DESCRIPTION
Note: this scenario was not going to happen, as it would have been super bad to our business.

The idea behind this is to add one more layer of security for users in case the protocol fee is changed after an airstream campaign is created. 

This would have been an issue if the expiration were set to 0, resulting in all funds being permanently locked and unable to be clawed back. Effectively, this would have allowed us to take a percentage of any airstream campaign that is created.
