### PR TITLE
build: install deps in prepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "gas:snapshot:optimized": "pnpm build:optimized && FOUNDRY_PROFILE=test-optimized forge snapshot --no-match-test \"test(Fork)?(Fuzz)?_RevertWhen_\\w{1,}?\"",
     "lint": "pnpm lint:sol && pnpm prettier:check",
     "lint:sol": "forge fmt --check && pnpm solhint \"{script,src,test}/**/*.sol\"",
-    "prepack": "bash ./shell/prepare-artifacts.sh",
+    "prepack": "pnpm install && bash ./shell/prepare-artifacts.sh",
     "prettier:check": "prettier --check \"**/*.{json,md,yml}\"",
     "prettier:write": "prettier --write \"**/*.{json,md,yml}\"",
     "test": "forge test",


### PR DESCRIPTION
To prevent accidental cases whereby the node modules are not updated when the package is published to the npm registry.