### PR TITLE
refactor: remove protocol fee checks in `MerkleStreamerLL`

### DIFF
--- a/src/SablierV2MerkleStreamerLL.sol
+++ b/src/SablierV2MerkleStreamerLL.sol
@@ -50,7 +50,7 @@ contract SablierV2MerkleStreamerLL is
         bool cancelable,
         bool transferable
     )
-        SablierV2MerkleStreamer(initialAdmin, asset, lockupLinear, merkleRoot, expiration, cancelable, transferable)
+        SablierV2MerkleStreamer(initialAdmin, asset, merkleRoot, expiration, cancelable, transferable)
     {
         LOCKUP_LINEAR = lockupLinear;
         streamDurations = streamDurations_;

--- a/src/interfaces/ISablierV2MerkleStreamer.sol
+++ b/src/interfaces/ISablierV2MerkleStreamer.sol
@@ -47,9 +47,6 @@ interface ISablierV2MerkleStreamer is IAdminable {
     /// @notice Returns a flag indicating whether the Merkle streamer has expired.
     function hasExpired() external view returns (bool);
 
-    /// @notice The address of the {SablierV2Lockup} contract.
-    function LOCKUP() external returns (ISablierV2Lockup);
-
     /// @notice The root of the Merkle tree used to validate the claims.
     /// @dev This is an immutable state variable.
     function MERKLE_ROOT() external returns (bytes32);

--- a/src/interfaces/ISablierV2MerkleStreamer.sol
+++ b/src/interfaces/ISablierV2MerkleStreamer.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.8.22;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IAdminable } from "@sablier/v2-core/src/interfaces/IAdminable.sol";
-import { ISablierV2Lockup } from "@sablier/v2-core/src/interfaces/ISablierV2Lockup.sol";
 
 /// @title ISablierV2MerkleStreamer
 /// @notice A contract that lets user claim Sablier streams using Merkle proofs. An interesting use case for
@@ -62,9 +61,6 @@ interface ISablierV2MerkleStreamer is IAdminable {
     /// @notice Claws back the unclaimed tokens from the Merkle streamer.
     ///
     /// @dev Emits a {Clawback} event.
-    ///
-    /// Notes:
-    /// - If the protocol is not zero, the expiration check is not made.
     ///
     /// Requirements:
     /// - The caller must be the admin.

--- a/src/interfaces/ISablierV2MerkleStreamerLL.sol
+++ b/src/interfaces/ISablierV2MerkleStreamerLL.sol
@@ -29,7 +29,6 @@ interface ISablierV2MerkleStreamerLL is ISablierV2MerkleStreamer {
     /// Requirements:
     /// - The campaign must not have expired.
     /// - The stream must not have been claimed already.
-    /// - The protocol fee must be zero.
     /// - The Merkle proof must be valid.
     ///
     /// @param index The index of the recipient in the Merkle tree.

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -23,9 +23,6 @@ library Errors {
     /// @notice Thrown when trying to claim with an invalid Merkle proof.
     error SablierV2MerkleStreamer_InvalidProof();
 
-    /// @notice Thrown when trying to claim when the protocol fee is not zero.
-    error SablierV2MerkleStreamer_ProtocolFeeNotZero();
-
     /// @notice Thrown when trying to claim the same stream more than once.
     error SablierV2MerkleStreamer_StreamClaimed(uint256 index);
 }

--- a/test/integration/merkle-streamer/ll/claim/claim.tree
+++ b/test/integration/merkle-streamer/ll/claim/claim.tree
@@ -16,7 +16,9 @@ claim.t.sol
       │     └── it should revert
       └── given the claim is included in the Merkle tree
          ├── given the protocol fee is greater than zero
-         │  └── it should revert
+         │  ├── it should mark the index as claimed
+         │  ├── it should create a LockupLinear stream
+         │  └── it should emit a {Claim} event
          └── given the protocol fee is not greater than zero
             ├── it should mark the index as claimed
             ├── it should create a LockupLinear stream

--- a/test/integration/merkle-streamer/ll/clawback/clawback.t.sol
+++ b/test/integration/merkle-streamer/ll/clawback/clawback.t.sol
@@ -2,7 +2,6 @@
 pragma solidity >=0.8.22 <0.9.0;
 
 import { Errors as V2CoreErrors } from "@sablier/v2-core/src/libraries/Errors.sol";
-import { ud } from "@prb/math/src/UD60x18.sol";
 
 import { Errors } from "src/libraries/Errors.sol";
 
@@ -24,11 +23,7 @@ contract Clawback_Integration_Test is MerkleStreamer_Integration_Test {
         _;
     }
 
-    modifier givenProtocolFeeZero() {
-        _;
-    }
-
-    function test_RevertGiven_CampaignNotExpired() external whenCallerAdmin givenProtocolFeeZero {
+    function test_RevertGiven_CampaignNotExpired() external whenCallerAdmin {
         vm.expectRevert(
             abi.encodeWithSelector(
                 Errors.SablierV2MerkleStreamer_CampaignNotExpired.selector, block.timestamp, defaults.EXPIRATION()
@@ -44,21 +39,11 @@ contract Clawback_Integration_Test is MerkleStreamer_Integration_Test {
         _;
     }
 
-    function test_Clawback() external whenCallerAdmin givenProtocolFeeZero givenCampaignExpired {
+    function test_Clawback() external whenCallerAdmin givenCampaignExpired {
         test_Clawback(users.admin);
     }
 
-    modifier givenProtocolFeeNotZero() {
-        comptroller.setProtocolFee({ asset: asset, newProtocolFee: ud(0.03e18) });
-        _;
-    }
-
-    function testFuzz_Clawback_CampaignNotExpired(address to) external whenCallerAdmin givenProtocolFeeNotZero {
-        vm.assume(to != address(0));
-        test_Clawback(to);
-    }
-
-    function testFuzz_Clawback(address to) external whenCallerAdmin givenCampaignExpired givenProtocolFeeNotZero {
+    function testFuzz_Clawback(address to) external whenCallerAdmin givenCampaignExpired {
         vm.assume(to != address(0));
         test_Clawback(to);
     }

--- a/test/integration/merkle-streamer/ll/clawback/clawback.tree
+++ b/test/integration/merkle-streamer/ll/clawback/clawback.tree
@@ -2,16 +2,8 @@ clawback.t.sol
 ├── when the caller is not the admin
 │  └── it should revert
 └── when the caller is the admin
-   ├── given the protocol fee is not greater than zero
-   │  ├── given the campaign has not expired
-   │  │  └── it should revert
-   │  └── given the campaign has expired
-   │     ├── it should perform the ERC-20 transfer
-   │     └── it should emit a {Clawback} event
-   └── given the protocol fee is greater than zero
-      ├── given the campaign has not expired
-      │  ├── it should perform the ERC-20 transfer
-      │  └── it should emit a {Clawback} event
-      └── given the campaign has expired
-         ├── it should perform the ERC-20 transfer
-         └── it should emit a {Clawback} event
+   ├── given the campaign has not expired
+   │  └── it should revert
+   └── given the campaign has expired
+      ├── it should perform the ERC-20 transfer
+      └── it should emit a {Clawback} event


### PR DESCRIPTION
Closes #256 

## Description
This PR removes protocol fee checks in MerkleStreamerLL and allows claiming even when the protocol fee is greater than 0. When $protocolFee>0$ then ${claimAmount}=(amount - protocolFee)$.

## Changes
- **SablierV2MerkleStreamer.sol** - Removes protocol fee checks in `_checkClaim` and `clawback`.
- **Errors.sol** - Removes `SablierV2MerkleStreamer_ProtocolFeeNotZero`.

## Testing
- **claim.t.sol**: Removes `test_RevertGiven_ProtocolFeeNotZero` and adds `test_Claim_ProtocolFeeNotZero`.
- **clawback.t.sol**: Removes modifiers `givenProtocolFeeZero` and `givenProtocolFeeNotZero` as clawback does not check for protocol fee anymore 
- Updates branching trees.

#### Related: https://github.com/sablier-labs/company-discussions/discussions/28