### PR TITLE
ci: use reusable workflows

### DIFF
--- a/.github/workflows/ci-deep.yml
+++ b/.github/workflows/ci-deep.yml
@@ -1,67 +1,42 @@
 name: "CI Deep"
 
-env:
-  RPC_URL_MAINNET: ${{ secrets.RPC_URL_MAINNET }}
-
 on:
   schedule:
     - cron: "0 3 * * 0" # at 3:00am UTC every Sunday
   workflow_dispatch:
     inputs:
+      integrationFuzzRuns:
+        default: "100000"
+        description: "Integration: number of fuzz runs."
+        required: false
       forkFuzzRuns:
-        default: "250"
-        description: "Number of fuzz runs for each fork test."
+        default: "1000"
+        description: "Fork: number of fuzz runs."
         required: false
 
 jobs:
   lint:
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: "Check out the repo"
-        uses: "actions/checkout@v4"
+    uses: "sablier-labs/reusable-workflows/.github/workflows/forge-lint.yml@main"
 
-      - name: "Install Foundry"
-        uses: "foundry-rs/foundry-toolchain@v1"
+  build:
+    uses: "sablier-labs/reusable-workflows/.github/workflows/forge-build.yml@main"
 
-      - name: "Install Bun"
-        uses: "oven-sh/setup-bun@v1"
+  test-integration:
+    needs: ["lint", "build"]
+    uses: "sablier-labs/reusable-workflows/.github/workflows/forge-test.yml@main"
+    with:
+      foundry-fuzz-runs: ${{ inputs.integrationFuzzRuns || 100000 }}
+      foundry-profile: "test-optimized"
+      match-path: "test/integration/**/*.sol"
+      name: "Integration tests"
 
-      - name: "Install the Node.js dependencies"
-        run: "bun install --frozen-lockfile"
-
-      - name: "Lint the code"
-        run: "bun run lint"
-
-      - name: "Add lint summary"
-        run: |
-          echo "## Lint result" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Passed" >> $GITHUB_STEP_SUMMARY
-
-  test:
-    env:
-      FOUNDRY_FUZZ_RUNS: ${{ inputs.forkFuzzRuns || '250' }}
-    needs: "lint"
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: "Check out the repo"
-        uses: "actions/checkout@v4"
-
-      - name: "Install Foundry"
-        uses: "foundry-rs/foundry-toolchain@v1"
-
-      - name: "Install Bun"
-        uses: "oven-sh/setup-bun@v1"
-
-      - name: "Install the Node.js dependencies"
-        run: "bun install --frozen-lockfile"
-
-      - name: "Produce an optimized build with --via-ir"
-        run: "FOUNDRY_PROFILE=optimized forge build"
-
-      - name: "Run the fork tests against the optimized build"
-        run: "FOUNDRY_PROFILE=test-optimized forge test --match-path \"test/fork/**/*.sol\""
-
-      - name: "Add test summary"
-        run: |
-          echo "## Fork tests result" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Passed" >> $GITHUB_STEP_SUMMARY
+  test-fork:
+    needs: ["lint", "build"]
+    secrets:
+      RPC_URL_MAINNET: ${{ secrets.RPC_URL_MAINNET }}
+    uses: "sablier-labs/reusable-workflows/.github/workflows/forge-test.yml@main"
+    with:
+      foundry-fuzz-runs: ${{ inputs.forkFuzzRuns || 1000 }}
+      foundry-profile: "test-optimized"
+      match-path: "test/fork/**/*.sol"
+      name: "Fork tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,6 @@ concurrency:
   cancel-in-progress: true
   group: ${{github.workflow}}-${{github.ref}}
 
-env:
-  RPC_URL_MAINNET: ${{ secrets.RPC_URL_MAINNET }}
-
 on:
   workflow_dispatch:
   pull_request:
@@ -16,194 +13,40 @@ on:
 
 jobs:
   lint:
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: "Check out the repo"
-        uses: "actions/checkout@v4"
-
-      - name: "Install Foundry"
-        uses: "foundry-rs/foundry-toolchain@v1"
-
-      - name: "Install Bun"
-        uses: "oven-sh/setup-bun@v1"
-
-      - name: "Install the Node.js dependencies"
-        run: "bun install --frozen-lockfile"
-
-      - name: "Lint the code"
-        run: "bun run lint"
-
-      - name: "Add lint summary"
-        run: |
-          echo "## Lint result" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Passed" >> $GITHUB_STEP_SUMMARY
+    uses: "sablier-labs/reusable-workflows/.github/workflows/forge-lint.yml@main"
 
   build:
-      runs-on: "ubuntu-latest"
-      steps:
-        - name: "Check out the repo"
-          uses: "actions/checkout@v4"
-
-        - name: "Install Foundry"
-          uses: "foundry-rs/foundry-toolchain@v1"
-
-        - name: "Install Bun"
-          uses: "oven-sh/setup-bun@v1"
-
-        - name: "Install the Node.js dependencies"
-          run: "bun install --frozen-lockfile"
-
-        - name: "Show the Foundry config"
-          run: "forge config"
-
-        - name: "Generate and prepare the contract artifacts"
-          run: "./shell/prepare-artifacts.sh"
-
-        - name: "Build the test contracts"
-          run: "FOUNDRY_PROFILE=test-optimized forge build"
-
-        - name: "Cache the build and the node modules so that they can be re-used by the other jobs"
-          uses: "actions/cache/save@v3"
-          with:
-            key: "build-and-modules-${{ github.sha }}"
-            path: |
-              cache
-              node_modules
-              out
-              out-optimized
-
-        - name: "Store the contract artifacts in CI"
-          uses: "actions/upload-artifact@v3"
-          with:
-            name: "contract-artifacts"
-            path: "artifacts"
-
-        - name: "Add build summary"
-          run: |
-            echo "## Build result" >> $GITHUB_STEP_SUMMARY
-            echo "✅ Passed" >> $GITHUB_STEP_SUMMARY
+    uses: "sablier-labs/reusable-workflows/.github/workflows/forge-build.yml@main"
 
   test-integration:
     needs: ["lint", "build"]
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: "Check out the repo"
-        uses: "actions/checkout@v4"
-
-      - name: "Install Foundry"
-        uses: "foundry-rs/foundry-toolchain@v1"
-
-      - name: "Restore the cached build and the node modules"
-        uses: "actions/cache/restore@v3"
-        with:
-          fail-on-cache-miss: true
-          key: "build-and-modules-${{ github.sha }}"
-          path: |
-            cache
-            node_modules
-            out
-            out-optimized
-
-      - name: "Run the integration tests against the optimized build"
-        run: "FOUNDRY_PROFILE=test-optimized forge test --match-path \"test/integration/**/*.sol\""
-
-      - name: "Add test summary"
-        run: |
-          echo "## Integration tests result" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Passed" >> $GITHUB_STEP_SUMMARY
+    uses: "sablier-labs/reusable-workflows/.github/workflows/forge-test.yml@main"
+    with:
+      foundry-fuzz-runs: 5000
+      foundry-profile: "test-optimized"
+      match-path: "test/integration/**/*.sol"
+      name: "Integration tests"
 
   test-utils:
     needs: ["lint", "build"]
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: "Check out the repo"
-        uses: "actions/checkout@v4"
-
-      - name: "Install Foundry"
-        uses: "foundry-rs/foundry-toolchain@v1"
-
-      - name: "Restore the cached build and the node modules"
-        uses: "actions/cache/restore@v3"
-        with:
-          fail-on-cache-miss: true
-          key: "build-and-modules-${{ github.sha }}"
-          path: |
-            cache
-            node_modules
-            out
-            out-optimized
-
-      - name: "Run the utils tests against the optimized build"
-        run: "FOUNDRY_PROFILE=test-optimized forge test --match-path \"test/utils/**/*.sol\""
-
-      - name: "Add test summary"
-        run: |
-          echo "## Utils tests result" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Passed" >> $GITHUB_STEP_SUMMARY
+    uses: "sablier-labs/reusable-workflows/.github/workflows/forge-test.yml@main"
+    with:
+      foundry-profile: "test-optimized"
+      match-path: "test/utils/**/*.sol"
+      name: "Utils tests"
 
   test-fork:
     needs: ["lint", "build"]
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: "Check out the repo"
-        uses: "actions/checkout@v4"
-
-      - name: "Install Foundry"
-        uses: "foundry-rs/foundry-toolchain@v1"
-
-      - name: "Restore the cached build and the node modules"
-        uses: "actions/cache/restore@v3"
-        with:
-          fail-on-cache-miss: true
-          key: "build-and-modules-${{ github.sha }}"
-          path: |
-            cache
-            node_modules
-            out
-            out-optimized
-
-      - name: "Generate fuzz seed that changes weekly to avoid burning through RPC allowance"
-        run: |
-          echo "FOUNDRY_FUZZ_SEED=$(echo $(($EPOCHSECONDS / 604800)))" >> $GITHUB_ENV
-
-      - name: "Run the fork tests against the optimized build"
-        run: "FOUNDRY_PROFILE=test-optimized forge test --match-path \"test/fork/**/*.sol\""
-
-      - name: "Add test summary"
-        run: |
-          echo "## Fork tests result" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Passed" >> $GITHUB_STEP_SUMMARY
+    secrets:
+      RPC_URL_MAINNET: ${{ secrets.RPC_URL_MAINNET }}
+    uses: "sablier-labs/reusable-workflows/.github/workflows/forge-test.yml@main"
+    with:
+      foundry-profile: "test-optimized"
+      match-path: "test/fork/**/*.sol"
+      name: "Fork tests"
 
   coverage:
     needs: ["lint", "build"]
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: "Check out the repo"
-        uses: "actions/checkout@v4"
-
-      - name: "Restore the cached build and the node modules"
-        uses: "actions/cache/restore@v3"
-        with:
-          fail-on-cache-miss: true
-          key: "build-and-modules-${{ github.sha }}"
-          path: |
-            cache
-            node_modules
-            out
-            out-optimized
-
-      - name: "Install Foundry"
-        uses: "foundry-rs/foundry-toolchain@v1"
-
-      - name: "Run the integration tests and generate the coverage report"
-        run: "forge coverage --match-path \"test/integration/**/*.sol\" --report lcov"
-
-      - name: "Upload coverage report to Codecov"
-        uses: "codecov/codecov-action@v3"
-        with:
-          files: "./lcov.info"
-
-      - name: "Add coverage summary"
-        run: |
-          echo "## Coverage result" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Uploaded to Codecov" >> $GITHUB_STEP_SUMMARY
+    uses: "sablier-labs/reusable-workflows/.github/workflows/forge-coverage.yml@main"
+    with:
+      match-path: "test/integration/**/*.sol"

--- a/.github/workflows/deploy-periphery.yml
+++ b/.github/workflows/deploy-periphery.yml
@@ -14,7 +14,6 @@ on:
         description: "Chain name as defined in the Foundry config."
         required: false
 
-
 jobs:
   deploy-periphery:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,24 +7,4 @@ on:
 
 jobs:
   stale:
-    runs-on: "ubuntu-latest"
-    steps:
-      - uses: "actions/stale@v9"
-        with:
-          close-issue-message: "This issue was closed because it has been stalled for 14 days with no activity."
-          close-issue-reason: "not_planned"
-          close-pr-message: "This PR was closed because it has been stalled for 7 days with no activity."
-          days-before-issue-close: 14
-          days-before-issue-stale: 182
-          days-before-pr-close: 7
-          days-before-pr-stale: 90
-          exempt-issue-labels: "help,priority0"
-          operations-per-run: 1000
-          stale-issue-label: "stale"
-          stale-issue-message:
-            'This issue is stale because it has been open 6 months with no activity. Leave a comment or remove the
-            "stale" label, otherwise this will be closed in 14 days.'
-          stale-pr-label: "stale"
-          stale-pr-message:
-            'This PR is stale because it has been open 3 months with no activity. Leave a comment or remove the "stale"
-            label, otherwise this will be closed in 7 days.'
+    uses: "sablier-labs/reusable-workflows/.github/workflows/stale.yml@main"


### PR DESCRIPTION
Closes #152.

This PR reduces the complexity of our CI workflows by de-duplicating as much logic as possible. Most of the jobs in the CI workflows are now reusable, and they can be imported from this repository:

https://github.com/sablier-labs/reusable-workflows

Please look at the README of that repository for more details on what workflows are available.