### PR TITLE
test: fix bound related bug in fork tests

### DIFF
--- a/test/fork/merkle-streamer/MerkleStreamerLL.t.sol
+++ b/test/fork/merkle-streamer/MerkleStreamerLL.t.sol
@@ -74,7 +74,9 @@ abstract contract MerkleStreamerLL_Fork_Test is Fork_Test {
             vars.indexes[i] = params.leafData[i].index;
 
             // Bound each leaf amount so that `aggregateAmount` does not overflow.
-            vars.amounts[i] = uint128(_bound(params.leafData[i].amount, 1, MAX_UINT256 / vars.recipientsCount - 1));
+            params.leafData[i].amount =
+                uint128(_bound(params.leafData[i].amount, 1, MAX_UINT256 / vars.recipientsCount - 1));
+            vars.amounts[i] = params.leafData[i].amount;
             vars.aggregateAmount += params.leafData[i].amount;
 
             // Avoid zero recipient addresses.


### PR DESCRIPTION
Resolves #277.

## Bug fixed by this PR

The following lines bound `vars.amounts[i]` to [1, BIGNUM] but not `params.leafData[i].amount`.

https://github.com/sablier-labs/v2-periphery/blob/a0712caabd87d6425df56854a66eadd9e061e876/test/fork/merkle-streamer/MerkleStreamerLL.t.sol#L76-L78

That means if `params.leafData[i].amount` is 0, `vars.aggregateAmount` would be 0 but `vars.amounts[i]` would be non-zero. 

This would lead to the token dealing with 0 amount but `.claim()` would be called with non-zero value of `vars.amounts` causing `ERC20: transfer amount exceeds balance` since there would be 0 balance in merkleStreamerLL contract.

https://github.com/sablier-labs/v2-periphery/blob/a0712caabd87d6425df56854a66eadd9e061e876/test/fork/merkle-streamer/MerkleStreamerLL.t.sol#L124

https://github.com/sablier-labs/v2-periphery/blob/a0712caabd87d6425df56854a66eadd9e061e876/test/fork/merkle-streamer/MerkleStreamerLL.t.sol#L153-L158