### PR TITLE
feat: store ipfsCID as a public variable

### DIFF
--- a/script/CreateMerkleLockupLL.s.sol
+++ b/script/CreateMerkleLockupLL.s.sol
@@ -15,7 +15,6 @@ contract CreateMerkleLockupLL is BaseScript {
         MerkleLockup.ConstructorParams baseParams;
         ISablierV2LockupLinear lockupLinear;
         LockupLinear.Durations streamDurations;
-        string ipfsCID;
         uint256 campaignTotalAmount;
         uint256 recipientsCount;
     }
@@ -32,7 +31,6 @@ contract CreateMerkleLockupLL is BaseScript {
             params.baseParams,
             params.lockupLinear,
             params.streamDurations,
-            params.ipfsCID,
             params.campaignTotalAmount,
             params.recipientsCount
         );

--- a/src/SablierV2MerkleLockupFactory.sol
+++ b/src/SablierV2MerkleLockupFactory.sol
@@ -21,7 +21,6 @@ contract SablierV2MerkleLockupFactory is ISablierV2MerkleLockupFactory {
         MerkleLockup.ConstructorParams memory baseParams,
         ISablierV2LockupLinear lockupLinear,
         LockupLinear.Durations memory streamDurations,
-        string memory ipfsCID,
         uint256 aggregateAmount,
         uint256 recipientsCount
     )
@@ -33,6 +32,7 @@ contract SablierV2MerkleLockupFactory is ISablierV2MerkleLockupFactory {
             abi.encodePacked(
                 baseParams.initialAdmin,
                 baseParams.asset,
+                abi.encode(baseParams.ipfsCID),
                 bytes32(abi.encodePacked(baseParams.name)),
                 baseParams.merkleRoot,
                 baseParams.expiration,
@@ -48,7 +48,7 @@ contract SablierV2MerkleLockupFactory is ISablierV2MerkleLockupFactory {
 
         // Using a different function to emit the event to avoid stack too deep error.
         emit CreateMerkleLockupLL(
-            merkleLockupLL, baseParams, lockupLinear, streamDurations, ipfsCID, aggregateAmount, recipientsCount
+            merkleLockupLL, baseParams, lockupLinear, streamDurations, aggregateAmount, recipientsCount
         );
     }
 }

--- a/src/abstracts/SablierV2MerkleLockup.sol
+++ b/src/abstracts/SablierV2MerkleLockup.sol
@@ -42,6 +42,9 @@ abstract contract SablierV2MerkleLockup is
     /// @inheritdoc ISablierV2MerkleLockup
     bool public immutable override TRANSFERABLE;
 
+    /// @inheritdoc ISablierV2MerkleLockup
+    string public ipfsCID;
+
     /// @dev Packed booleans that record the history of claims.
     BitMaps.BitMap internal _claimedBitMap;
 
@@ -63,6 +66,7 @@ abstract contract SablierV2MerkleLockup is
         ASSET = params.asset;
         CANCELABLE = params.cancelable;
         EXPIRATION = params.expiration;
+        ipfsCID = params.ipfsCID;
         MERKLE_ROOT = params.merkleRoot;
         NAME = bytes32(abi.encodePacked(params.name));
         TRANSFERABLE = params.transferable;

--- a/src/interfaces/ISablierV2MerkleLockup.sol
+++ b/src/interfaces/ISablierV2MerkleLockup.sol
@@ -46,6 +46,9 @@ interface ISablierV2MerkleLockup is IAdminable {
     /// @notice Returns a flag indicating whether the campaign has expired.
     function hasExpired() external view returns (bool);
 
+    /// @notice The content identifier for indexing the contract on IPFS.
+    function ipfsCID() external view returns (string memory);
+
     /// @notice The root of the Merkle tree used to validate the claims.
     /// @dev This is an immutable state variable.
     function MERKLE_ROOT() external returns (bytes32);

--- a/src/interfaces/ISablierV2MerkleLockupFactory.sol
+++ b/src/interfaces/ISablierV2MerkleLockupFactory.sol
@@ -20,7 +20,6 @@ interface ISablierV2MerkleLockupFactory {
         MerkleLockup.ConstructorParams indexed baseParams,
         ISablierV2LockupLinear lockupLinear,
         LockupLinear.Durations streamDurations,
-        string ipfsCID,
         uint256 aggregateAmount,
         uint256 recipientsCount
     );
@@ -35,7 +34,6 @@ interface ISablierV2MerkleLockupFactory {
     /// {DataTypes}.
     /// @param lockupLinear The address of the {SablierV2LockupLinear} contract.
     /// @param streamDurations The durations for each stream due to the recipient.
-    /// @param ipfsCID Metadata parameter emitted for indexing purposes.
     /// @param aggregateAmount Total amount of ERC-20 assets to be streamed to all recipients.
     /// @param recipientsCount Total number of recipients eligible to claim.
     /// @return merkleLockupLL The address of the newly created Merkle Lockup contract.
@@ -43,7 +41,6 @@ interface ISablierV2MerkleLockupFactory {
         MerkleLockup.ConstructorParams memory baseParams,
         ISablierV2LockupLinear lockupLinear,
         LockupLinear.Durations memory streamDurations,
-        string memory ipfsCID,
         uint256 aggregateAmount,
         uint256 recipientsCount
     )

--- a/src/types/DataTypes.sol
+++ b/src/types/DataTypes.sol
@@ -66,6 +66,7 @@ library MerkleLockup {
     /// @notice Struct encapsulating the base constructor parameter of a {SablierV2MerkleLockup} contract.
     /// @param initialAdmin The initial admin of the Merkle Lockup contract.
     /// @param asset The address of the streamed ERC-20 asset.
+    /// @param ipfsCID The content identifier for indexing the contract on IPFS.
     /// @param name The name of the campaign.
     /// @param merkleRoot The Merkle root of the claim data.
     /// @param expiration The expiration of the streaming campaign, as a Unix timestamp.
@@ -74,6 +75,7 @@ library MerkleLockup {
     struct ConstructorParams {
         address initialAdmin;
         IERC20 asset;
+        string ipfsCID;
         string name;
         bytes32 merkleRoot;
         uint40 expiration;

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -274,6 +274,7 @@ abstract contract Base_Test is DeployOptimized, Events, Merkle, V2CoreAssertions
             abi.encodePacked(
                 admin,
                 address(asset_),
+                abi.encode(defaults.IPFS_CID()),
                 defaults.NAME_BYTES32(),
                 merkleRoot,
                 expiration,

--- a/test/fork/merkle-lockup/MerkleLockupLL.t.sol
+++ b/test/fork/merkle-lockup/MerkleLockupLL.t.sol
@@ -108,7 +108,6 @@ abstract contract MerkleLockupLL_Fork_Test is Fork_Test {
             baseParams: vars.baseParams,
             lockupLinear: lockupLinear,
             streamDurations: defaults.durations(),
-            ipfsCID: defaults.IPFS_CID(),
             aggregateAmount: vars.aggregateAmount,
             recipientsCount: vars.recipientsCount
         });
@@ -117,7 +116,6 @@ abstract contract MerkleLockupLL_Fork_Test is Fork_Test {
             baseParams: vars.baseParams,
             lockupLinear: lockupLinear,
             streamDurations: defaults.durations(),
-            ipfsCID: defaults.IPFS_CID(),
             aggregateAmount: vars.aggregateAmount,
             recipientsCount: vars.recipientsCount
         });

--- a/test/integration/merkle-lockup/MerkleLockup.t.sol
+++ b/test/integration/merkle-lockup/MerkleLockup.t.sol
@@ -58,7 +58,6 @@ abstract contract MerkleLockup_Integration_Test is Integration_Test {
             baseParams: defaults.baseParams(admin, dai, defaults.MERKLE_ROOT(), expiration),
             lockupLinear: lockupLinear,
             streamDurations: defaults.durations(),
-            ipfsCID: defaults.IPFS_CID(),
             aggregateAmount: defaults.AGGREGATE_AMOUNT(),
             recipientsCount: defaults.RECIPIENTS_COUNT()
         });

--- a/test/integration/merkle-lockup/factory/create-merkle-lockup-ll/createMerkleLockupLL.t.sol
+++ b/test/integration/merkle-lockup/factory/create-merkle-lockup-ll/createMerkleLockupLL.t.sol
@@ -17,7 +17,6 @@ contract CreateMerkleLockupLL_Integration_Test is MerkleLockup_Integration_Test 
     function test_RevertWhen_CampaignNameTooLong() external {
         MerkleLockup.ConstructorParams memory baseParams = defaults.baseParams();
         LockupLinear.Durations memory streamDurations = defaults.durations();
-        string memory ipfsCID = defaults.IPFS_CID();
         uint256 aggregateAmount = defaults.AGGREGATE_AMOUNT();
         uint256 recipientsCount = defaults.RECIPIENTS_COUNT();
 
@@ -33,7 +32,6 @@ contract CreateMerkleLockupLL_Integration_Test is MerkleLockup_Integration_Test 
             baseParams: baseParams,
             lockupLinear: lockupLinear,
             streamDurations: streamDurations,
-            ipfsCID: ipfsCID,
             aggregateAmount: aggregateAmount,
             recipientsCount: recipientsCount
         });
@@ -47,7 +45,6 @@ contract CreateMerkleLockupLL_Integration_Test is MerkleLockup_Integration_Test 
     function test_RevertGiven_AlreadyCreated() external whenCampaignNameIsNotTooLong {
         MerkleLockup.ConstructorParams memory baseParams = defaults.baseParams();
         LockupLinear.Durations memory streamDurations = defaults.durations();
-        string memory ipfsCID = defaults.IPFS_CID();
         uint256 aggregateAmount = defaults.AGGREGATE_AMOUNT();
         uint256 recipientsCount = defaults.RECIPIENTS_COUNT();
 
@@ -56,7 +53,6 @@ contract CreateMerkleLockupLL_Integration_Test is MerkleLockup_Integration_Test 
             baseParams: baseParams,
             lockupLinear: lockupLinear,
             streamDurations: streamDurations,
-            ipfsCID: ipfsCID,
             aggregateAmount: aggregateAmount,
             recipientsCount: recipientsCount
         });
@@ -90,7 +86,6 @@ contract CreateMerkleLockupLL_Integration_Test is MerkleLockup_Integration_Test 
             baseParams: baseParams,
             lockupLinear: lockupLinear,
             streamDurations: defaults.durations(),
-            ipfsCID: defaults.IPFS_CID(),
             aggregateAmount: defaults.AGGREGATE_AMOUNT(),
             recipientsCount: defaults.RECIPIENTS_COUNT()
         });

--- a/test/integration/merkle-lockup/ll/constructor/constructor.t.sol
+++ b/test/integration/merkle-lockup/ll/constructor/constructor.t.sol
@@ -13,6 +13,7 @@ contract Constructor_MerkleLockupLL_Integration_Test is MerkleLockup_Integration
         address actualAdmin;
         uint256 actualAllowance;
         address actualAsset;
+        string actualIpfsCID;
         string actualName;
         bool actualCancelable;
         bool actualTransferable;
@@ -23,6 +24,7 @@ contract Constructor_MerkleLockupLL_Integration_Test is MerkleLockup_Integration
         address expectedAdmin;
         uint256 expectedAllowance;
         address expectedAsset;
+        string expectedIpfsCID;
         bytes32 expectedName;
         bool expectedCancelable;
         bool expectedTransferable;
@@ -78,5 +80,9 @@ contract Constructor_MerkleLockupLL_Integration_Test is MerkleLockup_Integration
         vars.actualAllowance = dai.allowance(address(constructedLockupLL), address(lockupLinear));
         vars.expectedAllowance = MAX_UINT256;
         assertEq(vars.actualAllowance, vars.expectedAllowance, "allowance");
+
+        vars.actualIpfsCID = constructedLockupLL.ipfsCID();
+        vars.expectedIpfsCID = defaults.IPFS_CID();
+        assertEq(vars.actualIpfsCID, vars.expectedIpfsCID, "ipfsCID");
     }
 }

--- a/test/utils/Defaults.sol
+++ b/test/utils/Defaults.sol
@@ -133,6 +133,7 @@ contract Defaults is Merkle {
         return MerkleLockup.ConstructorParams({
             initialAdmin: admin,
             asset: asset_,
+            ipfsCID: IPFS_CID,
             name: NAME,
             merkleRoot: merkleRoot,
             expiration: expiration,

--- a/test/utils/Events.sol
+++ b/test/utils/Events.sol
@@ -16,7 +16,6 @@ abstract contract Events {
         MerkleLockup.ConstructorParams indexed baseParams,
         ISablierV2LockupLinear lockupLinear,
         LockupLinear.Durations streamDurations,
-        string ipfsCID,
         uint256 aggregateAmount,
         uint256 recipientsCount
     );


### PR DESCRIPTION
Closes #281.

## Note 
- `ipfsCID` is included in the `MerkleLockup.ConstructorParams` struct.
- `ipfsCID` is stored as `string` because of it's [nondeterministic CID length](https://www.perplexity.ai/search/Is-there-a-V3lp4P9jSFGUSd0GzElVhA?s=c).