### PR TITLE
chore: refactor CreateMerkle scripts to deploy merkle lockup instances

### DIFF
--- a/script/CreateMerkleLL.s.sol
+++ b/script/CreateMerkleLL.s.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.8.22 <0.9.0;
 
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ISablierV2LockupLinear } from "@sablier/v2-core/src/interfaces/ISablierV2LockupLinear.sol";
 import { LockupLinear } from "@sablier/v2-core/src/types/DataTypes.sol";
 
@@ -11,30 +12,32 @@ import { ISablierV2MerkleLockupFactory } from "../src/interfaces/ISablierV2Merkl
 import { MerkleLockup } from "../src/types/DataTypes.sol";
 
 contract CreateMerkleLL is BaseScript {
-    struct Params {
-        MerkleLockup.ConstructorParams baseParams;
-        ISablierV2LockupLinear lockupLinear;
-        LockupLinear.Durations streamDurations;
-        uint256 campaignTotalAmount;
-        uint256 recipientCount;
-    }
-
     /// @dev Deploy via Forge.
-    function run(
-        ISablierV2MerkleLockupFactory merkleLockupFactory,
-        Params calldata params
-    )
-        public
-        virtual
-        broadcast
-        returns (ISablierV2MerkleLL merkleLL)
-    {
+    function run() public virtual broadcast returns (ISablierV2MerkleLL merkleLL) {
+        // Prepare the constructor parameters.
+        ISablierV2MerkleLockupFactory merkleLockupFactory =
+            ISablierV2MerkleLockupFactory(0xF35aB407CF28012Ba57CAF5ee2f6d6E4420253bc);
+
+        MerkleLockup.ConstructorParams memory baseParams;
+        baseParams.asset = IERC20(0x6B175474E89094C44Da98b954EedeAC495271d0F);
+        baseParams.cancelable = true;
+        baseParams.expiration = uint40(block.timestamp + 30 days);
+        baseParams.initialAdmin = 0x79Fb3e81aAc012c08501f41296CCC145a1E15844;
+        baseParams.ipfsCID = "QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR";
+        baseParams.merkleRoot = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        baseParams.name = "The Boys LL";
+        baseParams.transferable = true;
+
+        ISablierV2LockupLinear lockupLinear = ISablierV2LockupLinear(0x3962f6585946823440d274aD7C719B02b49DE51E);
+        LockupLinear.Durations memory streamDurations;
+        streamDurations.cliff = 0;
+        streamDurations.total = 3600;
+        uint256 campaignTotalAmount = 10_000e18;
+        uint256 recipientCount = 100;
+
+        // Deploy MerkleLL contract.
         merkleLL = merkleLockupFactory.createMerkleLL(
-            params.baseParams,
-            params.lockupLinear,
-            params.streamDurations,
-            params.campaignTotalAmount,
-            params.recipientCount
+            baseParams, lockupLinear, streamDurations, campaignTotalAmount, recipientCount
         );
     }
 }

--- a/script/CreateMerkleLT.s.sol
+++ b/script/CreateMerkleLT.s.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.8.22 <0.9.0;
 
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { UD2x18 } from "@prb/math/src/UD2x18.sol";
 import { ISablierV2LockupTranched } from "@sablier/v2-core/src/interfaces/ISablierV2LockupTranched.sol";
 
 import { BaseScript } from "./Base.s.sol";
@@ -10,30 +12,34 @@ import { ISablierV2MerkleLT } from "../src/interfaces/ISablierV2MerkleLT.sol";
 import { MerkleLockup, MerkleLT } from "../src/types/DataTypes.sol";
 
 contract CreateMerkleLT is BaseScript {
-    struct Params {
-        MerkleLockup.ConstructorParams baseParams;
-        ISablierV2LockupTranched lockupTranched;
-        MerkleLT.TrancheWithPercentage[] tranchesWithPercentages;
-        uint256 campaignTotalAmount;
-        uint256 recipientCount;
-    }
-
     /// @dev Deploy via Forge.
-    function run(
-        ISablierV2MerkleLockupFactory merkleLockupFactory,
-        Params calldata params
-    )
-        public
-        virtual
-        broadcast
-        returns (ISablierV2MerkleLT merkleLT)
-    {
+    function run() public virtual broadcast returns (ISablierV2MerkleLT merkleLT) {
+        // Prepare the constructor parameters.
+        ISablierV2MerkleLockupFactory merkleLockupFactory =
+            ISablierV2MerkleLockupFactory(0xF35aB407CF28012Ba57CAF5ee2f6d6E4420253bc);
+
+        MerkleLockup.ConstructorParams memory baseParams;
+        baseParams.asset = IERC20(0x6B175474E89094C44Da98b954EedeAC495271d0F);
+        baseParams.cancelable = true;
+        baseParams.expiration = uint40(block.timestamp + 30 days);
+        baseParams.initialAdmin = 0x79Fb3e81aAc012c08501f41296CCC145a1E15844;
+        baseParams.ipfsCID = "QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR";
+        baseParams.merkleRoot = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        baseParams.name = "The Boys LT";
+        baseParams.transferable = true;
+
+        ISablierV2LockupTranched lockupTranched = ISablierV2LockupTranched(0xf86B359035208e4529686A1825F2D5BeE38c28A8);
+        MerkleLT.TrancheWithPercentage[] memory tranchesWithPercentages = new MerkleLT.TrancheWithPercentage[](2);
+        tranchesWithPercentages[0] =
+            MerkleLT.TrancheWithPercentage({ unlockPercentage: UD2x18.wrap(50), duration: 3600 });
+        tranchesWithPercentages[1] =
+            MerkleLT.TrancheWithPercentage({ unlockPercentage: UD2x18.wrap(50), duration: 7200 });
+        uint256 campaignTotalAmount = 10_000e18;
+        uint256 recipientCount = 100;
+
+        // Deploy MerkleLT contract.
         merkleLT = merkleLockupFactory.createMerkleLT(
-            params.baseParams,
-            params.lockupTranched,
-            params.tranchesWithPercentages,
-            params.campaignTotalAmount,
-            params.recipientCount
+            baseParams, lockupTranched, tranchesWithPercentages, campaignTotalAmount, recipientCount
         );
     }
 }

--- a/test/fork/Fork.t.sol
+++ b/test/fork/Fork.t.sol
@@ -2,7 +2,6 @@
 pragma solidity >=0.8.22 <0.9.0;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { Precompiles as V2CorePrecompiles } from "@sablier/v2-core/precompiles/Precompiles.sol";
 import { ISablierV2LockupDynamic } from "@sablier/v2-core/src/interfaces/ISablierV2LockupDynamic.sol";
 import { ISablierV2LockupLinear } from "@sablier/v2-core/src/interfaces/ISablierV2LockupLinear.sol";
 import { ISablierV2LockupTranched } from "@sablier/v2-core/src/interfaces/ISablierV2LockupTranched.sol";


### PR DESCRIPTION
The objective of  having `CreateMerkleLL` and `CreateMerkleLT` scripts is to deploy instances of merkle lockup and verify them on-chain so that etherscan can automatically verify other lockups deployed by the users.

However, its time consuming to construct the parameters of `run` command. This PR makes it easier to achieve the same objective by setting all parameters inside the script itself.

```shell
FOUNDRY_PROFILE=optimized \
forge script script/CreateMerkleLL.s.sol \
--broadcast --etherscan-api-key $ETHERSCAN_API_KEY \
--rpc-url mainnet --sig "run()" \
--verify -vvv
```